### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,12 +51,12 @@ stop-all:
 # Initialize all agents
 init-agents:
 	@echo "Initializing all agents..."
-	docker compose exec -it jivas bash -c "jvcli initagents"
+	docker compose exec -it jivas bash -c "jvcli server initagents"
 	@echo "Agents initialized."
 
 # Import a specific agent
 import-agent:
-	docker compose exec -it jivas bash -c "jvcli importagent $(AGENT)"
+	docker compose exec -it jivas bash -c "jvcli server importagent $(AGENT)"
 
 # Clean MongoDB data
 clean-db:


### PR DESCRIPTION
This pull request updates the `Makefile` to modify the commands used for initializing and importing agents. The changes ensure that the `jvcli` commands explicitly reference the `server` subcommand.

Updates to agent-related commands:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L54-R59): Updated the `init-agents` target to use `jvcli server initagents` instead of `jvcli initagents`.
* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L54-R59): Updated the `import-agent` target to use `jvcli server importagent $(AGENT)` instead of `jvcli importagent $(AGENT)`.